### PR TITLE
specify signature type for adoptium verifier

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -9,6 +9,7 @@ jobs:
   call-adoptium-verifier:
     uses: adoptium/marketplace-data/.github/workflows/validate-data.yml@main
     with:
+      signature-type: BASE64_ENCODED
       public-key: |
         -----BEGIN PUBLIC KEY-----
         MIICIjANBgkqhkiG9w0BAQEFAAOCAg8AMIICCgKCAgEAoWlAyGsyYfaE42vvMjr0


### PR DESCRIPTION
We had to add the signature type so that the verifier could handle both file types

CC @tellison 